### PR TITLE
feat: update pubsub emulator to use the latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:alpine as builder
+FROM golang:alpine AS builder
 
 RUN apk update && apk upgrade && apk add --no-cache curl git
 
 RUN curl -s https://raw.githubusercontent.com/eficode/wait-for/master/wait-for -o /usr/bin/wait-for
 RUN chmod +x /usr/bin/wait-for
 
-RUN go get github.com/floatschedule/pubsubc
+RUN go install github.com/floatschedule/pubsubc@latest
 
 ###############################################################################
 
@@ -19,4 +19,4 @@ RUN apk --update add openjdk8-jre netcat-openbsd && gcloud components install be
 
 EXPOSE 8681
 
-CMD /run.sh
+CMD ["/run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -5,7 +5,9 @@
 #
 # After it's done, port 8682 will be open to facilitate the wait-for and
 # wait-for-it scripts.
-(/usr/bin/wait-for localhost:8681 -- env PUBSUB_EMULATOR_HOST=localhost:8681 /usr/bin/pubsubc -debug; nc -lkp 8682 >/dev/null) &
+echo "Starting initialization script ..."
+(/usr/bin/wait-for localhost:8681 --timeout=600 -- env PUBSUB_EMULATOR_HOST=localhost:8681 /usr/bin/pubsubc -debug; nc -lkp 8682 >/dev/null) &
 
+echo "Starting emulator ..."
 # Start the PubSub emulator in the foreground.
 gcloud beta emulators pubsub start --host-port=0.0.0.0:8681 "$@"


### PR DESCRIPTION
In this PR i'm updating the Dockerfile to run the latest pubsub emulator version.

I'm also adding a timeout of 10m to the wait-for script. The reason for this is that I noticed the pubsub emulator comes up in about 4 minutes, while the default timeout was 15s, so the topic and subscription initialization script was failing. 